### PR TITLE
Fixing SOURCE_BRANCH allow list

### DIFF
--- a/.github/scripts/check-branch-name.sh
+++ b/.github/scripts/check-branch-name.sh
@@ -4,8 +4,8 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SOURCE_BRANCH=${1:-$CURRENT_BRANCH}
 TARGET_BRANCH=$2
 
-if [[ ! $SOURCE_BRANCH =~ ^(feature|bugfix|hotfix|release)/.+$ ]]; then
-  echo "Branch name $SOURCE_BRANCH must be of the form '^(feature|bugfix|hotfix|release)/*'"
+if [[ ! $SOURCE_BRANCH =~ ^(feature|bugfix|hotfix|release)/.+$ ]] && [[ ! $SOURCE_BRANCH == develop ]]; then
+  echo "Branch name $SOURCE_BRANCH must be of the form '^(feature|bugfix|hotfix|release)/*' or 'develop'"
   exit 1
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ That is, given a version number `MAJOR.MINOR.PATCH`, increment the:
 - **PATCH** version when you make backwards compatible bug fixes
 
 
+## [1.3.6](https://github.com/collier-p-charlie/fsio/compare/1.3.5...1.3.6) 2025-08-08
+
+### Amended
+- Fixing error where `SOURCE_BRANCH` cannot be `develop` for `main` merge.
+
+
 ## [1.3.5](https://github.com/collier-p-charlie/fsio/compare/1.3.4...1.3.5) 2025-08-08
 
 ### Amended

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fsio"
-version = "1.3.5"  # https://packaging.python.org/en/latest/discussions/versioning/
+version = "1.3.6"  # https://packaging.python.org/en/latest/discussions/versioning/
 dependencies = []
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
## Summary

Allowing `$SOURCE_BRANCH` to be `develop` for `develop` to `main` **PR**s.

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup / refactoring
- [ ] 📝 Documentation update
- [ ] ✅ Tests added / updated

---

## Checklist

- [ ] Do all the unit tests run locally (see [here](./workflows/run-tests.yaml)).
- [ ] Have you ensured the correctness of the new _documentation_ using `mkdocs serve` locally.

---

## Related Issues

Closes #<issue_number>
Related to #<issue_number>

---

## Additional Information

> Any additional context, concerns, or open questions you want feedback on.
